### PR TITLE
When renaming a folder, every item in the database has its vector recalculated

### DIFF
--- a/model/folder.mjs
+++ b/model/folder.mjs
@@ -323,7 +323,7 @@ export async function tree (user) {
  */
 export async function updateFTS (id) {
   const cfolders = await children(id)
-  cfolders.push(id)
+  cfolders.push({ id })
 
   for (const f of cfolders) {
     const items = await DB.items.findMany({


### PR DESCRIPTION
Fixes #87