### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,5 +1,7 @@
 name: Run tests
 on: push
+permissions:
+  contents: read
 
 jobs:
   # Label of the runner job


### PR DESCRIPTION
Potential fix for [https://github.com/steunix/passweaver-api/security/code-scanning/10](https://github.com/steunix/passweaver-api/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for most workflows that only need to read repository contents. Since the workflow does not appear to require any write permissions or access to other resources, this minimal permission level adheres to the principle of least privilege.

The `permissions` block will be added immediately after the `name` and `on` keys in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
