### PR TITLE
When accessing a one time secret shared with user, fix error message if not logged in

### DIFF
--- a/api/v1/controllers/onetimetokens.mjs
+++ b/api/v1/controllers/onetimetokens.mjs
@@ -60,7 +60,7 @@ export async function get (req, res, next) {
   }
 
   // Check token scope
-  if (ottoken.scope === Const.OTT_SCOPE_LOGGEDIN && req?.user === undefined) {
+  if ((ottoken.scope === Const.OTT_SCOPE_LOGGEDIN || ottoken.scope === Const.OTT_SCOPE_USER) && req?.user === undefined) {
     res.status(R.FORBIDDEN).send(R.ko('In order to show this secret, you need to login'))
     return
   }


### PR DESCRIPTION
Fixes #247